### PR TITLE
feat: extract cart into it own component

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -10,13 +10,5 @@
     </div>
   </section>
 
-  <section class="cart">
-    <h2>Your Cart (0)</h2>
-    <div class="content">
-      <div class="empty-cart-content">
-        <img src="images/illustration-empty-cart.svg" alt="empty cart svg" />
-        <p class="empty-cart-description">Your added items will appear here</p>
-      </div>
-    </div>
-  </section>
+  <app-cart></app-cart>
 </main>

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -31,30 +31,4 @@ main {
   width: 100%;
   height: 100%;
 }
-// cart section
-.cart {
-  width: 300px;
-  height: fit-content;
-  flex: 1 0 380px;
-  padding: 1rem;
 
-  h2 {
-    @include TextPreset2;
-    color: $red;
-  }
-
-  .content {
-    width: 100%;
-    height: fit-content;
-
-    .empty-cart-content {
-      @include flex(column, center, center);
-      width: 100%;
-
-      p {
-        @include TextPreset4Bold;
-        color: $rose-500;
-      }
-    }
-  }
-}

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -5,10 +5,10 @@ import { CommonModule } from '@angular/common';
 import { Dessert } from './core/models/dessert.model';
 import { DessertService } from './services/dessert.service';
 import { DessertItemComponent } from './components/dessert-item/dessert-item.component';
-
+import { CartComponent } from './components/cart/cart.component';
 @Component({
   selector: 'app-root',
-  imports: [CommonModule, DessertItemComponent],
+  imports: [CommonModule, DessertItemComponent,CartComponent],
   templateUrl: './app.component.html',
   styleUrl: './app.component.scss',
 })

--- a/src/app/components/cart/cart.component.html
+++ b/src/app/components/cart/cart.component.html
@@ -1,0 +1,9 @@
+<section class="cart">
+  <h2>Your Cart (0)</h2>
+  <div class="content">
+    <div class="empty-cart-content">
+      <img src="images/illustration-empty-cart.svg" alt="empty cart svg" />
+      <p class="empty-cart-description">Your added items will appear here</p>
+    </div>
+  </div>
+</section>

--- a/src/app/components/cart/cart.component.scss
+++ b/src/app/components/cart/cart.component.scss
@@ -1,0 +1,30 @@
+@use "../../styles/variables" as *;
+@use "../../styles/mixins" as *;
+
+// cart section
+.cart {
+  width: 300px;
+  height: fit-content;
+  flex: 1 0 380px;
+  padding: 1rem;
+
+  h2 {
+    @include TextPreset2;
+    color: $red;
+  }
+
+  .content {
+    width: 100%;
+    height: fit-content;
+
+    .empty-cart-content {
+      @include flex(column, center, center);
+      width: 100%;
+
+      p {
+        @include TextPreset4Bold;
+        color: $rose-500;
+      }
+    }
+  }
+}

--- a/src/app/components/cart/cart.component.spec.ts
+++ b/src/app/components/cart/cart.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { CartComponent } from './cart.component';
+
+describe('CartComponent', () => {
+  let component: CartComponent;
+  let fixture: ComponentFixture<CartComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [CartComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(CartComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/components/cart/cart.component.ts
+++ b/src/app/components/cart/cart.component.ts
@@ -1,0 +1,11 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-cart',
+  imports: [],
+  templateUrl: './cart.component.html',
+  styleUrl: './cart.component.scss'
+})
+export class CartComponent {
+  
+}

--- a/src/app/components/dessert-item/dessert-item.component.html
+++ b/src/app/components/dessert-item/dessert-item.component.html
@@ -1,6 +1,6 @@
 <div class="dessert-item">
   <section class="item-image-add-to-cart">
-    <img src="{{ dessert.image.thumbnail }}" alt="dessert image" />
+    <img src="{{ dessert.image.thumbnail }}" alt="{{ dessert.name }}" />
     <app-add-to-cart />
   </section>
   <section class="item-info">


### PR DESCRIPTION
This pull request introduces a new change where the cart template in the `app.component.html` file is extracted into it own component adhering to separation of concerns and keeping the `app.component.html` file more modular and cleaner